### PR TITLE
Changing the sum_numbers functions so it doesn't fail with strings

### DIFF
--- a/sciware_testing_python/main.py
+++ b/sciware_testing_python/main.py
@@ -25,9 +25,10 @@ def sum_numbers(number_list):
     1
     """
 
-    sum_val = 0
-    for n in number_list:
-        sum_val += n
+    sum_val = number_list[0]
+    for i in range(1, len(number_list)):
+        sum_val += number_list[i]
+
 
     return sum_val
 


### PR DESCRIPTION
When I went through the module, feeding sum_numbers a list of strings actually doesn't work (you can't use the `+=` operator with an `int` on the lhs and a `str` on the rhs). So I think we should switch the code to something like the following:

```python
    sum_val = number_list[0]
    for i in range(1, len(number_list)):
        sum_val += number_list[i]
```

I know it's a bit clunkier, but it will have the desired behavior.