### PR TITLE
Adding codecov to GitHub Actions

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -24,4 +24,11 @@ jobs:
       run: pip install .
 
     - name: Test
-      run: pytest --doctest-modules
+      run: pytest --doctest-modules --cov=./
+      
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        name: example-codecov
+        token: c8fb235d-d1bc-45cf-9575-a32ed97eb8ee # PUT YOUR TOKEN HERE
+        fail_ci_if_error: true

--- a/.github/workflows/exercise.yml
+++ b/.github/workflows/exercise.yml
@@ -22,3 +22,13 @@ jobs:
 
     - name: Install
       run: pip install .
+    
+    # - name: Test
+    #   run: #ADD TEST commands here
+
+    # - name: Codecov
+    #   uses: codecov/codecov-action@v1
+    #   with:
+    #     name: exercise-codecov
+    #     token:  # PUT YOUR TOKEN HERE
+    #     fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ __pycache__/
 .mypy_cache/
 /*.egg-info/
 /.eggs/
-.gitignore
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 .mypy_cache/
 /*.egg-info/
 /.eggs/
+.gitignore

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Sciware Testing Examples and Exercises
 
 [![](https://github.com/flatironinstitute/sciware-testing-python/actions/workflows/test.yml/badge.svg)](https://github.com/flatironinstitute/sciware-testing-python/actions)
+[![codecov](https://codecov.io/gh/jamesETsmith/sciware-testing-python/branch/main/graph/badge.svg?token=4z1jy9YqIV)](https://codecov.io/gh/jamesETsmith/sciware-testing-python)
 
 This is an example repository for writing tests, for the Sciware Testing session. 
 It demonstrates how to setup a repository to use GitHub actions to automatically run tests


### PR DESCRIPTION
I've added codecov steps to the GitHub actions workflows. For the "fully worked" example, everything is set up, for the user example it's just skeleton code.